### PR TITLE
Add Versioning to Enums, in a backward compatible way

### DIFF
--- a/infi/pyutils/enums.py
+++ b/infi/pyutils/enums.py
@@ -1,40 +1,143 @@
-import itertools
-from .python_compat import (
-    basestring,
-    itervalues,
-    OrderedDict,
-    )
+from packaging.version import Version, parse
+from .python_compat import OrderedDict, itervalues
 
+ALL = '0.0'
+LATEST = '1000000.0'
 
-class Value(object):
+class UnboundException(AttributeError):
+    pass
+
+def _convert(version):
+    if version is None:
+        return None
+    if not isinstance(version, Version):
+        return parse(version)
+    return version
+
+class VersionedBase(object):
+    def __init__(self, version=ALL):
+        self._version = _convert(version)
+
+    def as_version(self, version):
+        bound = self._copy()
+        bound.bind_to_version(version)
+        return bound
+
+    def bind_to_version(self, version):
+        self._version = _convert(version)
+
+    def is_bound(self):
+        return self._version is not None
+
+    def get_bound_version(self):
+        return str(self._version) if self._version is not None else None
+
+class Value(VersionedBase):
     """
-    An Enum value that supports aliases
+    Create a value list, or a versioned value list. To specify versions, use a dict, otherwise, use a list of values.
+    
+    Example:
+    
+    >>> avg = VersionedValue('avg',['avg','Average','AVG'])
+    >>> avg == 'avg'
+    True
+    >>> avg == 'AVG'
+    True
+    >>> avg == 'AVERAGE'
+    False
+    
+    Versioned example:
+    
+    >>> avg = VersionedValue('avg',{'1.0':['avg','AVG'],'2.0':['Average','AVERAGE']})
+    >>> avg.as_version('1.0') == 'avg'
+    True
+    >>> avg.as_version('2.0') == 'avg'
+    False
+    >>> avg.as_version('2.0') == 'Average'
+    True    
+    
     """
-    def __init__(self, name, aliases = ()):
-        super(Value, self).__init__()
-        self._name = str(name)
-        self._aliases = set(aliases)
-    def __repr__(self):
-        return self._name.upper()
+    def __init__(self, key, list_or_dict=None, default_version=ALL, **kwargs):
+        super(Value, self).__init__(default_version)
+        if isinstance(key, Value):
+            key = key.get_value()
+        self._key = key
+        if list_or_dict is None:
+            list_or_dict = []
+        if isinstance(list_or_dict, dict):
+            self._construct_from_dict(list_or_dict)
+        else:
+            if 'aliases' in kwargs:
+                # For backwards compatibility with old non versioned enums
+                list_or_dict = kwargs.get('aliases')
+            self._construct_from_list(list_or_dict)
+
+    def _construct_from_list(self, values):
+        converted_values = [self._key]
+        for value in values:
+            if isinstance(value, Value):
+                converted_values.extend(value.get_values())
+            else:
+                converted_values.append(value)
+        self._construct_from_dict({ALL:converted_values})
+        self.bind_to_version(ALL)
+
+    def _construct_from_dict(self, values):
+        self._values = OrderedDict((_convert(k), values[k]) for k in reversed(sorted(values.keys())))
+
     def get_name(self):
-        return self._name
-    def __eq__(self, other):
-        if isinstance(other, basestring):
-            other = other.lower()
-        for possible_name in itertools.chain([self._name], self._aliases):
-            if (possible_name == other) or (isinstance(possible_name, basestring) and possible_name.lower() == other):
-                return True
-        return False
-    def __ne__(self, other):
-        return not (self == other)
-    def __hash__(self):
-        return self._name.__hash__()
+        return self._key
 
-class Enum(object):
+    def get_values(self):
+        if not self.is_bound():
+            raise UnboundException('Versioned value {0} is not bound'.format(self._key))
+        return self._get_values(raise_exc=True)
+
+    def _get_values(self, raise_exc=False):
+        for v in self._values.keys():
+            if self._version >= v:
+                return self._values[v]
+        if raise_exc:
+            raise UnboundException('No values of {0} could be found for version {1}'.format(self._key, self._version))
+        return []
+
+    def get_value(self):
+        values = self.get_values()
+        if values:
+            return values[0]
+        raise UnboundException('No value of {0} could be found for version {1}'.format(self._key, self._version))
+
+    def _copy(self):
+        return Value(self._key, self._values, default_version=self._version)
+
+    def __eq__(self, o):
+        compare_values = [str(v).lower() for v in self._get_values()]
+        if isinstance(o, Value):
+            other_values = [str(v).lower() for v in o._get_values()]
+        else:
+            other_values = [str(o).lower()]
+        return compare_values == other_values or any(v in compare_values for v in other_values)
+
+    def __ne__(self, o):
+        return not self == o
+    
+    def __getitem__(self, version):
+        return self.as_version(version)
+    
+    def __str__(self):
+        return self._key.upper()
+
+    def __repr__(self):
+        return "{{{0}:{1}}}".format(self._key, self._values)
+
+class Enum(VersionedBase):
     """
     An Enum class for python.
-
-    >>> x = Enum("TRUE",Value("FALSE", aliases=["NOT"]))
+    
+    >>> x = Enum(VersionedValue("True",{'1.0': ["TRUE"],
+                                        '2.0': ["True","yes"]}),
+                 VersionedValue("False",{'1.0': ["FALSE"],
+                                         '2.0': ["False","No"]}))
     >>> x.true
     TRUE
     >>> "TRUE" in x
@@ -46,26 +149,48 @@ class Enum(object):
     >>> "NOT" in x
     True
     >>> "FALSE" in x
-    True
+    True    
     """
-    def __init__(self, *states):
-        super(Enum, self).__init__()
-        self._states = OrderedDict()
-        for state in states:
-            if not isinstance(state, Value):
-                state = Value(state)
-            self._states[state._name.lower()] = state
-    def __getattr__(self, attr):
-        if attr.startswith("_"):
-            raise AttributeError(attr)
-        state = self._states.get(attr, None)
-        if state is None:
-            raise AttributeError(attr)
-        return state
+    def __init__(self, *values, **kwargs):
+        default_version = kwargs.get('default_version', ALL)
+        super(Enum, self).__init__(default_version)
+        self._values = OrderedDict()
+        for value in values:
+            if not isinstance(value, Value):
+                value = Value(value)
+            self._values[value._key.lower()] = value.as_version(default_version)
+
+    def bind_to_version(self, version):
+        super(Enum, self).bind_to_version(version)
+        for value in itervalues(self._values):
+            value.bind_to_version(version)
+            
+    def _copy(self):
+        return Enum(*itervalues(self._values), default_version=self._version)
+
+    def get(self, value):
+        if not self.is_bound():
+            raise UnboundException("Can't lookup value for unbound versioned dict")
+        for v in itervalues(self._values):
+            if v == value:
+                return v
+        raise UnboundException('Could not find matching value for {0}'.format(value))
+
     def __iter__(self):
-        return itervalues(self._states)
-    def get(self, attr):
-        for state in self._states.values():
-            if state == attr:
-                return state
-        raise AttributeError(attr)
+        return itervalues(self._values)
+
+    def __getattribute__(self, key):
+        if key.startswith('_'):
+            return super(Enum, self).__getattribute__(key)
+        try:
+            return self[key]
+        except KeyError:
+            return super(Enum, self).__getattribute__(key)
+
+    def __getitem__(self, key):
+        if isinstance(key, Enum):
+            key = key.get_value()
+        return self._values[key.lower()]
+
+    def __repr__(self):
+        return [v for v in itervalues(self._values)].__repr__()

--- a/infi/pyutils/versioned_group.py
+++ b/infi/pyutils/versioned_group.py
@@ -1,0 +1,170 @@
+from packaging.version import Version, parse
+
+ALL = '0.0'
+LATEST = '1000000.0'
+
+class UnboundException(Exception):
+    pass
+
+def _convert(version):
+    if version is None:
+        return None
+    if not isinstance(version, Version):
+        return parse(version)
+    return version
+
+class VersionedBase(object):
+    def __init__(self, version=None):
+        self._version = version
+
+    def as_version(self, version):
+        bound = self._copy()
+        bound.bind_to_version(version)
+        return bound
+
+    def bind_to_version(self, version):
+        self._version = _convert(version)
+
+    def is_bound(self):
+        return self._version is not None
+
+    def get_bound_version(self):
+        return str(self._version) if self._version is not None else None
+
+class VersionedValue(VersionedBase):
+    """
+    Create a value list, or a versioned value list. To specify versions, use a dict, otherwise, use a list of values.
+    
+    Example:
+    
+    >>> avg = VersionedValue('avg',['avg','Average','AVG'])
+    >>> avg == 'avg'
+    True
+    >>> avg == 'AVG'
+    True
+    >>> avg == 'AVERAGE'
+    False
+    
+    Versioned example:
+    
+    >>> avg = VersionedValue('avg',{'1.0':['avg','AVG'],'2.0':['Average','AVERAGE']})
+    >>> avg.as_version('1.0') == 'avg'
+    True
+    >>> avg.as_version('2.0') == 'avg'
+    False
+    >>> avg.as_version('2.0') == 'Average'
+    True    
+    
+    """
+    def __init__(self, key, list_or_dict=None, default_version=None):
+        super(VersionedValue, self).__init__(default_version)
+        self._key = key
+        if isinstance(list_or_dict, dict):
+            self._construct_from_dict(list_or_dict)
+        else:
+            self._construct_from_list(list_or_dict)
+
+    def _construct_from_list(self, values):
+        self._construct_from_dict({ALL:values})
+        self.bind_to_version(ALL)
+
+    def _construct_from_dict(self, values):
+        self._values = dict((_convert(k), v) for k, v in values.items())
+
+    def get_values(self):
+        if not self.is_bound():
+            raise UnboundException('Versioned value {0} is not bound'.format(self._key))
+        return self._get_values(raise_exc=True)
+
+    def _get_values(self, raise_exc=False):
+        for v in reversed(sorted(self._values.keys())):
+            if self._version >= v:
+                return self._values[v]
+        if raise_exc:
+            raise UnboundException('No values of {0} could be found for version {1}'.format(self._key, self._version))
+        return []
+
+    def get_value(self):
+        values = self.get_values()
+        if values:
+            return values[0]
+        raise UnboundException('No value of {0} could be found for version {1}'.format(self._key, self._version))
+
+    def _copy(self):
+        return VersionedValue(self._key, self._values, default_version=self._version)
+
+    def __eq__(self, o):
+        if isinstance(o, VersionedValue):
+            if self.is_bound() and o.is_bound():
+                return self._get_values() == o._get_values()
+        elif self.is_bound():
+            return o in self._get_values()
+
+        return False
+
+    def __ne__(self, o):
+        return not self == o
+    
+    def __getitem__(self, version):
+        return self.as_version(version)
+    
+    def __repr__(self):
+        return "{{{0}:{1}}}".format(self._key, self._values)
+
+class VersionedGroup(VersionedBase):
+    """
+    Create a value group, an emun of versioned values
+    
+    Example:
+    
+    >>> avg = VersionedValue('avg',['avg','Average','AVG'])
+    >>> avg == 'avg'
+    True
+    >>> avg == 'AVG'
+    True
+    >>> avg == 'AVERAGE'
+    False
+    
+    Versioned example:
+    
+    >>> avg = VersionedValue('avg',{'1.0':['avg','AVG'],'2.0':['Average','AVERAGE']})
+    >>> avg.as_version('1.0') == 'avg'
+    True
+    >>> avg.as_version('2.0') == 'avg'
+    False
+    >>> avg.as_version('2.0') == 'Average'
+    True    
+    
+    """
+    def __init__(self, *values, **kwargs):
+        default_version = kwargs.get('default_version', None)
+        super(VersionedGroup, self).__init__(default_version)
+        self._values = dict((value._key, value.as_version(default_version)) for value in values)
+
+    def __getattribute__(self, key):
+        try:
+            return super(VersionedGroup, self).__getattribute__(key)
+        except AttributeError:
+            return self._values[key]
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def bind_to_version(self, version):
+        super(VersionedGroup, self).bind_to_version(version)
+        for value in self._values.values():
+            value.bind_to_version(version)
+            
+    def _copy(self):
+        return VersionedGroup(*self._values.values(), default_version=self._version)
+
+    def find_value(self, value):
+        if not self.is_bound():
+            raise UnboundException("Can't lookup value for unbound versioned dict")
+        for v in self._values.values():
+            if v == value:
+                return v
+        raise UnboundException('Could not find matching value for {0}'.format(value))
+
+    def __repr__(self):
+        return self._values.values().__repr__()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 with open(os.path.join(os.path.dirname(__file__), "infi", "pyutils", "__version__.py")) as version_file:
     exec(version_file.read())
 
-install_requires = ["mock", "six", "emport"]
+install_requires = ["mock", "six", "emport", "packaging"]
 if sys.version_info < (2, 7):
     install_requires.append('unittest2')
     install_requires.append('ordereddict')

--- a/tests/test__enums.py
+++ b/tests/test__enums.py
@@ -1,70 +1,200 @@
 import copy
-from infi.pyutils.enums import Enum, Value
+from infi.pyutils.enums import Enum, Value, ALL, LATEST, UnboundException
 from .test_utils import TestCase
 
+class VersionedValueTest(TestCase):
+    def test_non_versioned_value(self):
+        versioned_value = Value('avg', ['AVERAGE', 'average', 'Average'])
+        assert versioned_value == 'avg' # key is in non versioned value for backward compat
+        assert versioned_value == 'AVERAGE'
+        assert versioned_value == 'average'
+        assert versioned_value == 'Average'
+        assert versioned_value != 'Median'
+        assert versioned_value.get_bound_version() == ALL
+
+    def versioned_value(self):
+        return Value('avg', {'1.0':['AVERAGE', 'average', 'Average'],
+                             '1.0.1':['Average', 'AVG'],
+                             '2.0':['Average', 'avg']})
+
+    def test_versioned_value(self):
+        versioned_value = self.versioned_value()
+        assert versioned_value.as_version('1.0') != 'avg' # key is not in versioned value
+        assert versioned_value.as_version('1.0') == 'average'
+        assert versioned_value.as_version('1.0.1') == 'AVG'
+        assert versioned_value.as_version('1.0.1') != 'median'
+        assert versioned_value.as_version('1.5') != 'median'
+        assert versioned_value.as_version('2.0') == 'avg'
+        assert versioned_value.as_version('2.0') != 'median'
+        assert versioned_value.as_version('2.5') == 'avg'
+        assert versioned_value.as_version('2.5') != 'median'
+        assert versioned_value.as_version(LATEST) == 'avg'
+        assert versioned_value.as_version(LATEST) != 'median'
+
+
+    def test_get_values(self):
+        versioned_value = self.versioned_value()
+        assert versioned_value.as_version('1.0').get_values() == ['AVERAGE', 'average', 'Average']
+        assert versioned_value.as_version('1.0.1').get_values() == ['Average', 'AVG']
+        assert versioned_value.as_version('1.5').get_values() == ['Average', 'AVG']
+        assert versioned_value.as_version('2.0').get_values() == ['Average', 'avg']
+        assert versioned_value.as_version('2.5').get_values() == ['Average', 'avg']
+
+    def test_get_value(self):
+        versioned_value = self.versioned_value()
+        assert versioned_value.as_version('1.0').get_value() == 'AVERAGE'
+        assert versioned_value.as_version('1.0.1').get_value() == 'Average'
+        assert versioned_value.as_version('1.5').get_value() == 'Average'
+        assert versioned_value.as_version('2.0').get_value() == 'Average'
+        assert versioned_value.as_version('2.5').get_value() == 'Average'
+
+    def test_bind_version(self):
+        versioned_value = self.versioned_value()
+        assert versioned_value.get_bound_version() == ALL
+        versioned_value.bind_to_version('2.5')
+        assert versioned_value.get_bound_version() == '2.5'
+        assert versioned_value.as_version('2.5').get_values() == ['Average', 'avg']
+        assert versioned_value.as_version('2.5').get_value() == 'Average'
+
+    def test_raises_unbound(self):
+        versioned_value = self.versioned_value()
+        with self.assertRaises(UnboundException):
+            versioned_value.get_values()
+        with self.assertRaises(UnboundException):
+            versioned_value.get_value()
+        with self.assertRaises(UnboundException):
+            versioned_value.as_version('0.1').get_values()
+        with self.assertRaises(UnboundException):
+            versioned_value.as_version('0.1').get_value()
+
+    def test_equal_values(self):
+        a = Value('a', {'1.0':['a', 'A'], '2.0':['A'], '3.0':['C']})
+        b = Value('b', {'1.0':['b', 'B'], '2.0':['A']})
+        assert a.as_version('1.0') == a.as_version('2.0')
+        assert a.as_version('1.0') != a.as_version('3.0')
+        assert a.as_version('1.0') == a.as_version('1.5')
+        assert a.as_version('2.0') == b.as_version('2.0')
+        assert a.as_version('1.0') != b.as_version('1.0')
+        assert a.as_version('0.1') == b.as_version('0.1')
+
+class VersionedEnumTest(TestCase):
+    def versioned_enum(self):
+        return Enum(Value('one', {'1.0':['One'],
+                                  '2.0':['1', 1, 'One'],
+                                  '2.5':['1', 1]}),
+                    Value('two', {'2.0':['2', 2, 'Two'],
+                                  '2.5':['2', 2]}))
+
+    def test_versioned_enum(self):
+        versioned_enum = self.versioned_enum()
+        assert versioned_enum.one.as_version('2.0').get_values() == ['1', 1, 'One']
+        assert versioned_enum['one'].as_version('2.0').get_values() == ['1', 1, 'One']
+        assert versioned_enum.as_version('2.0').one.get_values() == ['1', 1, 'One']
+        assert versioned_enum.as_version('2.0')['one'].get_values() == ['1', 1, 'One']
+        assert versioned_enum.as_version('2.0').two.get_values() == ['2', 2, 'Two']
+        assert versioned_enum.as_version('3.0').two.get_values() == ['2', 2]
+
+        with self.assertRaises(UnboundException):
+            versioned_enum.two.as_version('1.0').get_value()
+        with self.assertRaises(UnboundException):
+            versioned_enum.as_version('1.0').two.get_value()
+
+    def test_bound(self):
+        versioned_enum = self.versioned_enum()
+        versioned_enum.bind_to_version('2.0')
+        assert versioned_enum.one.get_values() == ['1', 1, 'One']
+        assert versioned_enum['one'].get_values() == ['1', 1, 'One']
+        assert versioned_enum.one.get_values() == ['1', 1, 'One']
+        assert versioned_enum['one'].get_values() == ['1', 1, 'One']
+        assert versioned_enum.two.get_values() == ['2', 2, 'Two']
+
+    def test_get(self):
+        versioned_enum = self.versioned_enum()
+        assert versioned_enum.as_version('1.0').get('One').get_values() == ['One']
+        assert versioned_enum.as_version('2.0').get('One').get_values() == ['1', 1, 'One']
+        assert versioned_enum.as_version('2.0').get(1).get_values() == ['1', 1, 'One']
+
+        with self.assertRaises(UnboundException):
+            versioned_enum.get('One')
+        with self.assertRaises(UnboundException):
+            versioned_enum.as_version('1.0').get(1)
+
+
 class EnumTestCase(TestCase):
+    """ The old enum behavior, we need to keep this working for backwards compatibility """
+
     def setUp(self):
-        self.enum = Enum("String", Value("VALUE", aliases = ["FIRST_ALIAS", "SECOND_ALIAS"]))
+        self.enum = Enum("String", Value("VALUE", aliases=["FIRST_ALIAS", "SECOND_ALIAS"]))
+
     def test__is_value(self):
         for e in self.enum:
             self.assertIsInstance(e, Value)
+
     def test__equals(self):
         self.assertEquality(self.enum.string, "String")
         self.assertEquality(self.enum.string, "STRING")
         self.assertEquality(self.enum.value, "VALUE")
         self.assertInequality(self.enum.value, self.enum.string)
         self.assertInequality(self.enum.string, "VALUE")
+
     def test__aliases(self):
         for alias in ("value", "Value", "VALUE", "FIRST_ALIAS", "SECOND_ALIAS", "second_alias"):
             self.assertEquality(self.enum.value, alias)
             self.assertEquality(Value(alias), self.enum.value)
             self.assertInequality(alias + "x", self.enum.value)
+
     def test__aliased_values(self):
         aliased_value = Value("aliased", aliases=[self.enum.value, self.enum.string])
         for alias in ("value", "Value", "VALUE", "FIRST_ALIAS", "SECOND_ALIAS", "second_alias", "String", self.enum.value, self.enum.string):
             self.assertEquality(aliased_value, alias)
             self.assertEquality(Value(alias), aliased_value)
             self.assertInequality(str(alias) + "x", aliased_value)
+
     def test__in(self):
         self.assertIn("String", self.enum)
         self.assertIn("VALUE", self.enum)
         self.assertIn("FIRST_ALIAS", self.enum)
         self.assertIn("SECOND_ALIAS", self.enum)
+
     def test__alias_is_not_a_value(self):
         self.assertRaises(AttributeError, getattr, self.enum, "first_alias")
+
     def test__iteration(self):
         self.assertEquality(list(self.enum), ["String", "VALUE"])
-    def test__str_repr(self):
-        for func in (str, repr):
-            self.assertEquality(func(self.enum.string), "STRING")
+
     def test__get(self):
         self.assertEqual(self.enum.value, self.enum.get("VALUE"))
         self.assertEqual(self.enum.value, self.enum.get("Value"))
         self.assertEqual(self.enum.value, self.enum.get("FIRST_ALIAS"))
         self.assertEqual(self.enum.value, self.enum.get("first_alias"))
         self.assertRaises(AttributeError, self.enum.get, "illegal")
+
     def test__get_attribute(self):
         self.assertEqual(self.enum.string, "String")
         with self.assertRaises(AttributeError):
             self.enum.fake_value
         with self.assertRaises(AttributeError):
             self.enum._fake_value
+
     def test__deepcopy(self):
         my_dict = {'a': 1, 'b': Enum('a', 'b', 'c', 'd')}
         dict_copy = copy.deepcopy(my_dict)
         self.assertEqual(my_dict['a'], dict_copy['a'])
         self.assertEqual(list(my_dict['b']), list(dict_copy['b']))
+
     def test__get_value_name(self):
         input_values = ["CamelCase", "lower_case", "UPPER_CASE"]
         enum = Enum(*input_values)
-        self.assertEqual([val.get_name() for val in enum], input_values)
-        self.assertEqual([str(val) for val in enum], [val.upper() for val in input_values])
+        self.assertEqual(sorted([val.get_name() for val in enum]), sorted(input_values))
+        self.assertEqual(sorted([str(val) for val in enum]), sorted([val.upper() for val in input_values]))
+
     def assertEquality(self, a, b):
         msg = "Equality check for {0!r} == {1!r} failed".format(a, b)
         self.assertTrue(a == b, msg)
         self.assertTrue(b == a, msg)
         self.assertFalse(a != b, msg)
         self.assertFalse(b != a, msg)
+
     def assertInequality(self, a, b):
         msg = "Inequality check for {0!r} != {1!r} failed".format(a, b)
         self.assertFalse(a == b, msg)

--- a/tests/test__versioned_group.py
+++ b/tests/test__versioned_group.py
@@ -1,0 +1,117 @@
+from .test_utils import TestCase
+from infi.pyutils.versioned_group import VersionedGroup, VersionedValue, ALL, LATEST, UnboundException
+
+class VersionedValueTest(TestCase):
+    def test_non_versioned_value(self):
+        versioned_value = VersionedValue('avg', ['AVERAGE', 'average', 'Average'])
+        assert versioned_value == 'AVERAGE'
+        assert versioned_value == 'average'
+        assert versioned_value == 'Average'
+        assert versioned_value != 'avg'
+        assert versioned_value != 'Median'
+        assert versioned_value.get_bound_version() == ALL
+
+    def versioned_value(self):
+        return VersionedValue('avg', {'1.0':['AVERAGE', 'average', 'Average'],
+                                      '1.0.1':['Average', 'AVG'],
+                                      '2.0':['Average', 'avg']})
+
+    def test_versioned_value(self):
+        versioned_value = self.versioned_value()
+        assert versioned_value.as_version('1.0') == 'average'
+        assert versioned_value.as_version('1.0.1') == 'AVG'
+        assert versioned_value.as_version('1.0.1') != 'average'
+        assert versioned_value.as_version('1.5') != 'average'
+        assert versioned_value.as_version('2.0') == 'avg'
+        assert versioned_value.as_version('2.0') != 'AVG'
+        assert versioned_value.as_version('2.5') == 'avg'
+        assert versioned_value.as_version('2.5') != 'AVG'
+        assert versioned_value.as_version(LATEST) != 'AVG'
+
+
+    def test_get_values(self):
+        versioned_value = self.versioned_value()
+        assert versioned_value.as_version('1.0').get_values() == ['AVERAGE', 'average', 'Average']
+        assert versioned_value.as_version('1.0.1').get_values() == ['Average', 'AVG']
+        assert versioned_value.as_version('1.5').get_values() == ['Average', 'AVG']
+        assert versioned_value.as_version('2.0').get_values() == ['Average', 'avg']
+        assert versioned_value.as_version('2.5').get_values() == ['Average', 'avg']
+
+    def test_get_value(self):
+        versioned_value = self.versioned_value()
+        assert versioned_value.as_version('1.0').get_value() == 'AVERAGE'
+        assert versioned_value.as_version('1.0.1').get_value() == 'Average'
+        assert versioned_value.as_version('1.5').get_value() == 'Average'
+        assert versioned_value.as_version('2.0').get_value() == 'Average'
+        assert versioned_value.as_version('2.5').get_value() == 'Average'
+
+    def test_bind_version(self):
+        versioned_value = self.versioned_value()
+        assert versioned_value.get_bound_version() is None
+        versioned_value.bind_to_version('2.5')
+        assert versioned_value.get_bound_version() == '2.5'
+        assert versioned_value.as_version('2.5').get_values() == ['Average', 'avg']
+        assert versioned_value.as_version('2.5').get_value() == 'Average'
+
+    def test_raises_unbound(self):
+        versioned_value = self.versioned_value()
+        with self.assertRaises(UnboundException):
+            versioned_value.get_values()
+        with self.assertRaises(UnboundException):
+            versioned_value.get_value()
+        with self.assertRaises(UnboundException):
+            versioned_value.as_version('0.1').get_values()
+        with self.assertRaises(UnboundException):
+            versioned_value.as_version('0.1').get_value()
+
+    def test_equal_values(self):
+        a = VersionedValue('a', {'1.0':['a', 'A'], '2.0':['A']})
+        b = VersionedValue('b', {'1.0':['b', 'B'], '2.0':['A']})
+        assert a != b
+        assert a.as_version('1.0') != a.as_version('2.0')
+        assert a.as_version('1.0') == a.as_version('1.5')
+        assert a.as_version('2.0') == b.as_version('2.0')
+        assert a.as_version('1.0') != b.as_version('1.0')
+        assert a.as_version('0.1') == b.as_version('0.1')
+
+class VersionedGroupTest(TestCase):
+    def versioned_group(self):
+        return VersionedGroup(VersionedValue('one', {'1.0':['One'],
+                                                     '2.0':['1', 1, 'One'],
+                                                     '2.5':['1', 1]}),
+                              VersionedValue('two', {'2.0':['2', 2, 'Two'],
+                                                     '2.5':['2', 2]}))
+
+    def test_versioned_group(self):
+        versioned_group = self.versioned_group()
+        assert versioned_group.one.as_version('2.0').get_values() == ['1', 1, 'One']
+        assert versioned_group['one'].as_version('2.0').get_values() == ['1', 1, 'One']
+        assert versioned_group.as_version('2.0').one.get_values() == ['1', 1, 'One']
+        assert versioned_group.as_version('2.0')['one'].get_values() == ['1', 1, 'One']
+        assert versioned_group.as_version('2.0').two.get_values() == ['2', 2, 'Two']
+        assert versioned_group.as_version('3.0').two.get_values() == ['2', 2]
+
+        with self.assertRaises(UnboundException):
+            versioned_group.two.as_version('1.0').get_value()
+        with self.assertRaises(UnboundException):
+            versioned_group.as_version('1.0').two.get_value()
+
+    def test_bound(self):
+        versioned_group = self.versioned_group()
+        versioned_group.bind_to_version('2.0')
+        assert versioned_group.one.get_values() == ['1', 1, 'One']
+        assert versioned_group['one'].get_values() == ['1', 1, 'One']
+        assert versioned_group.one.get_values() == ['1', 1, 'One']
+        assert versioned_group['one'].get_values() == ['1', 1, 'One']
+        assert versioned_group.two.get_values() == ['2', 2, 'Two']
+
+    def test_find_value(self):
+        versioned_group = self.versioned_group()
+        assert versioned_group.as_version('1.0').find_value('One').get_values() == ['One']
+        assert versioned_group.as_version('2.0').find_value('One').get_values() == ['1', 1, 'One']
+        assert versioned_group.as_version('2.0').find_value(1).get_values() == ['1', 1, 'One']
+    
+        with self.assertRaises(UnboundException):
+            versioned_group.find_value('One')
+        with self.assertRaises(UnboundException):
+            versioned_group.as_version('1.0').find_value(1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33
+envlist = py26,py27,py33,py34
 
 [testenv]
 deps=nose


### PR DESCRIPTION
The new Enum usage now supports version matching for values.